### PR TITLE
Fix infinite loop in Nightclub Money Loop

### DIFF
--- a/kiddions/Ultimate_Menu V14 1.67.lua
+++ b/kiddions/Ultimate_Menu V14 1.67.lua
@@ -10071,8 +10071,8 @@ L7NEGML = L7NEG7:add_submenu("Nighclub Money Loop 250k/10s")
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
 local isRunning = false
-local function safeLoop(state)
-    while state do
+local function safeLoop()
+    while isRunning do
         stats.set_int(MPX .. "CLUB_POPULARITY", 1000)
         stats.set_int(MPX .. "CLUB_PAY_TIME_LEFT", -1)
         sleep(1.5)
@@ -10098,7 +10098,7 @@ L7NEGML:add_toggle(
     end,
     function()
         isRunning = not isRunning
-        safeLoop(isRunning)
+        safeLoop()
     end
 )
 


### PR DESCRIPTION
Hi! Nice script.

I detected that while using safeLoop, once I tried to stop it I wasn't able to.
That's because the state var isn't updating at all.
I fixed it by linking the local var directly into the loop, and removing the state var. Another fix would be updating the state just at the end of the while iteration, but this solution seems cleaner to me.